### PR TITLE
Update bakehouse_etl.yml

### DIFF
--- a/Cookies-DataEng-DAB/resources/bakehouse_etl.yml
+++ b/Cookies-DataEng-DAB/resources/bakehouse_etl.yml
@@ -9,7 +9,7 @@ resources:
             path: ../src/DLT Flagship SQL.sql
       serverless: true
       development: false
-      catalog: bakehouse_active
+      catalog: bakehouse-active
       target: pipelines
       photon: true
       channel: PREVIEW


### PR DESCRIPTION
Corrects catalog name to bakehouse-active using "-" instead of "_" to correspond to instructions in README